### PR TITLE
allow to manually set up order of loading files by sorting them using numbers in files

### DIFF
--- a/lib/activerecord-database-views/view.rb
+++ b/lib/activerecord-database-views/view.rb
@@ -1,5 +1,7 @@
 module ActiveRecord::DatabaseViews
   class View
+    FILE_NAME_MATCHER_WITH_PREFIX = /^\d+?_(.+)/
+
     attr_reader :path
 
     def initialize(path)
@@ -15,10 +17,18 @@ module ActiveRecord::DatabaseViews
     end
 
     def name
-      File.basename(path, '.sql')
+      if basename =~ FILE_NAME_MATCHER_WITH_PREFIX
+        FILE_NAME_MATCHER_WITH_PREFIX.match(basename)[1]
+      else
+        basename
+      end
     end
 
     private
+
+    def basename
+      @basename ||= File.basename(path, '.sql')
+    end
 
     def full_path
       Rails.root.join(path)

--- a/lib/activerecord-database-views/view_collection.rb
+++ b/lib/activerecord-database-views/view_collection.rb
@@ -41,7 +41,7 @@ module ActiveRecord::DatabaseViews
     end
 
     def view_paths
-      Dir.glob('db/views/**/*.sql')
+      Dir.glob('db/views/**/*.sql').sort
     end
   end
 end


### PR DESCRIPTION
If .sql files contain prefix with numbers followed by underscore (1_, 2_, 001_, 002_, ...) then name of database view is extracted from file name by removing numbers and underscore:
- `001_inactive_users.sql` - will become `inactive_users`
- `inactive_users.sql` - will stay `inactive_users`
